### PR TITLE
Add context parameter and domain separation to match FIPS 205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added _ctx_ parameter to signing and verifying functions. Existing functions are are unchanged and
+  provide an empty string for _ctx_ per the FIPS 205 standard.
+
+### Changed
+
+- Comments and documentation which referenced the draft are updated to match the released standard.
+  This is mostly figure/table/algorithm/page/line numbers.
+
 ## 0.1.2 (2024-03-15)
 
 - Internal improvements, removed dependency on generic-array, MSRV at 1.70

--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 
-[FIPS 205] (Initial Public Draft) Stateless Hash-Based Digital Signature Standard written in pure Rust for server, 
+[FIPS 205] Stateless Hash-Based Digital Signature Standard written in pure Rust for server, 
 desktop, browser and embedded applications. The code repository includes C FFI and Python bindings.
 
-This crate implements the FIPS 205 **draft** standard in pure Rust with minimal and mainstream dependencies. All 
+This crate implements the FIPS 205 standard in pure Rust with minimal and mainstream dependencies. All 
 twelve (!!) security parameter sets are fully functional. The implementation does not require the standard library, 
 e.g. `#[no_std]`, has no heap allocations, e.g. no `alloc` needed, and exposes the `RNG` so it is suitable for the 
 full range of applications from server down to the bare-metal. The API is stabilized and the code is heavily biased 
 towards safety  and correctness; further performance optimizations will be implemented as the standard matures. 
-This crate will quickly follow any changes to FIPS 205 as they become available.
 
-See <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.ipd.pdf> for a full description of the target functionality.
+See <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf> for a full description of the target functionality.
 
 The functionality is extremely simple to use, as demonstrated by the following example.
 
@@ -50,7 +49,9 @@ desired [security parameter](#modules) below.
 
 ## Notes
 
-* This crate is fully functional and corresponds to the first initial public draft of FIPS 205.    
+* This crate corresponds to the first initial release of FIPS 205.
+* Pre-hash variants are not yet supported. These variants formalize methods for signing a hash of
+  the message instead of the message itself, along with meta data about the prehasher used.
 * Constant-time assurances target the source-code level only, and are a work in progress.
 * Note that FIPS 205 places specific requirements on randomness per section 3.1, hence the exposed `RNG`.
 * Requires Rust **1.70** or higher. The minimum supported Rust version may be changed in the future, 

--- a/ffi/fips205.py
+++ b/ffi/fips205.py
@@ -60,7 +60,7 @@ Thank you to Daniel Kahn Gillmor for providing an example for FIPS 203.
 
 ## See Also
 
-- https://doi.org/10.6028/NIST.FIPS.205.ipd
+- https://csrc.nist.gov/pubs/fips/205/final
 - https://github.com/integritychain/fips205
 
 """

--- a/src/fors.rs
+++ b/src/fors.rs
@@ -3,8 +3,8 @@ use crate::helpers::base_2b;
 use crate::types::{Adrs, Auth, ForsPk, ForsSig, FORS_PRF, FORS_ROOTS};
 
 
-/// Algorithm 13: `fors_SKgen(SK.seed, PK.seed, ADRS, idx)` on page 29.
-/// Generate a FORS private-key value.
+/// Algorithm 14: `fors_SKgen(SK.seed, PK.seed, ADRS, idx)` on page 29.
+/// Generates a FORS private-key value.
 ///
 /// Input: Secret seed `SK.seed`, public seed `PK.seed`, address `ADRS`, secret key index `idx`. <br>
 /// Output: n-byte FORS private-key value.
@@ -29,8 +29,8 @@ pub(crate) fn fors_sk_gen<const K: usize, const LEN: usize, const M: usize, cons
 }
 
 
-/// Algorithm 14: `fors_node(SK.seed, i, z, PK.seed, ADRS)` on page 30.
-/// Compute the root of a Merkle subtree of FORS public values.
+/// Algorithm 15: `fors_node(SK.seed, i, z, PK.seed, ADRS)` on page 30.
+/// Computes the root of a Merkle subtree of FORS public values.
 ///
 /// Input: Secret seed `SK.seed`, target node index `i`, target node height `z`, public seed `PK.seed`,
 /// address `ADRS`. <br>
@@ -48,59 +48,55 @@ pub(crate) fn fors_node<
     let (a32, k32) = (u32::try_from(A).unwrap(), u32::try_from(K).unwrap());
     let mut adrs = adrs.clone();
 
-    // 1: if z > a or i ≥ k · 2^(a−z) then
+    // Note this bounds check was only specified in the draft specification
     if (z > a32) | (i > k32 * (1 << (a32 - z))) {
-        //
-        // 2: return NULL
-        return Err("Alg14 fails");
-
-        // 3: end if
+        return Err("Alg15 failed");
     }
 
-    // 4: if z = 0 then
+    // 1: if z = 0 then
     let node = if z == 0 {
         //
-        // 5: sk ← fors_SKgen(SK.seed, PK.seed, ADRS, i)
+        // 2: sk ← fors_SKgen(SK.seed, PK.seed, ADRS, i)
         let sk = fors_sk_gen(hashers, sk_seed, pk_seed, &adrs, i);
 
-        // 6: ADRS.setTreeHeight(0)
+        // 3: ADRS.setTreeHeight(0)
         adrs.set_tree_height(0);
 
-        // 7: ADRS.setTreeIndex(i)
+        // 4: ADRS.setTreeIndex(i)
         adrs.set_tree_index(i);
 
-        // 8: node ← F(PK.seed, ADRS, sk)
+        // 5: node ← F(PK.seed, ADRS, sk)
         (hashers.f)(pk_seed, &adrs, &sk)
 
-        // 9: else
+        // 6: else
     } else {
         //
-        // 10: lnode ← fors_node(SK.seed, 2i, z − 1, PK.seed, ADRS)
+        // 7: lnode ← fors_node(SK.seed, 2i, z − 1, PK.seed, ADRS)
         let lnode = fors_node::<A, K, LEN, M, N>(hashers, sk_seed, 2 * i, z - 1, pk_seed, &adrs)?;
 
-        // 11: rnode ← fors_node(SK.seed, 2i + 1, z − 1, PK.seed, ADRS)
+        // 8: rnode ← fors_node(SK.seed, 2i + 1, z − 1, PK.seed, ADRS)
         let rnode =
             fors_node::<A, K, LEN, M, N>(hashers, sk_seed, 2 * i + 1, z - 1, pk_seed, &adrs)?;
 
-        // 12: ADRS.setTreeHeight(z)
+        // 9: ADRS.setTreeHeight(z)
         adrs.set_tree_height(z);
 
-        // 13: ADRS.setTreeIndex(i)
+        // 10: ADRS.setTreeIndex(i)
         adrs.set_tree_index(i);
 
-        // 14: node ← H(PK.seed, ADRS, lnode ∥ rnode)
+        // 11: node ← H(PK.seed, ADRS, lnode ∥ rnode)
         (hashers.h)(pk_seed, &adrs, &lnode, &rnode)
 
-        // 15: end if
+        // 12: end if
     };
 
-    // 16: return node
+    // 13: return node
     Ok(node)
 }
 
 
-/// Algorithm 15: `fors_sign(md, SK.seed, PK.seed, ADRS)`
-/// Generate a FORS signature.
+/// Algorithm 16: `fors_sign(md, SK.seed, PK.seed, ADRS)` on page 31
+/// Generates a FORS signature.
 ///
 /// Input: Message digest `md`, secret seed `SK.seed`, address `ADRS`, public seed `PK.seed`. <br>
 /// Output: FORS signature `SIG_FORS`.
@@ -122,7 +118,7 @@ pub(crate) fn fors_sign<
         auth: core::array::from_fn(|_| Auth { tree: [[0u8; N]; A] }),
     };
 
-    // 2: indices ← base_2^b(md, a, k)
+    // 2: indices ← base_2b(md, a, k)
     let mut indices = [0u32; K];
     base_2b(md, a32, k32, &mut indices);
 
@@ -138,14 +134,13 @@ pub(crate) fn fors_sign<
             i * (1 << a32) + indices[i as usize],
         );
 
-        // 5:
-        // 6: for j from 0 to a − 1 do    ▷ Compute auth path
+        // 5: for j from 0 to a − 1 do    ▷ Compute auth path
         for j in 0..a32 {
             //
-            // 7: s ← indices[i]/2^j xor 1
+            // 6: s ← indices[i]/2^j xor 1
             let s = (indices[i as usize] >> j) ^ 1;
 
-            // 8: AUTH[j] ← fors_node(SK.seed, i · 2^{a−j} + s, j, PK.seed, ADRS)
+            // 7: AUTH[j] ← fors_node(SK.seed, i · 2^{a−j} + s, j, PK.seed, ADRS)
             sig_fors.auth[i as usize].tree[j as usize] = fors_node::<A, K, LEN, M, N>(
                 hashers,
                 sk_seed,
@@ -155,22 +150,22 @@ pub(crate) fn fors_sign<
                 adrs,
             )?;
 
-            // 9: end for
+            // 8: end for
         }
 
-        // 10: SIG_FORS ← SIG_FORS ∥ AUTH
+        // 9: SIG_FORS ← SIG_FORS ∥ AUTH
         // built within inner loop above
 
-        // 11: end for
+        // 10: end for
     }
 
-    // 12: return SIG_FORS
+    // 11: return SIG_FORS
     Ok(sig_fors)
 }
 
 
-/// Algorithm 16: `fors_pkFromSig(SIG_FORS, md, PK.seed, ADRS)` on page 32.
-/// Compute a FORS public key from a FORS signature.
+/// Algorithm 17: `fors_pkFromSig(SIG_FORS, md, PK.seed, ADRS)` on page 32.
+/// Computes a FORS public key from a FORS signature.
 ///
 /// Input: FORS signature `SIG_FORS`, message digest `md`, public seed `PK.seed`, address `ADRS`. <br>
 /// Output: FORS public key.
@@ -188,7 +183,7 @@ pub(crate) fn fors_pk_from_sig<
     let (a32, k32) = (u32::try_from(A).unwrap(), u32::try_from(K).unwrap());
     let mut adrs = adrs.clone();
 
-    // 1: indices ← base_2^b(md, a, k)
+    // 1: indices ← base_2b(md, a, k)
     let mut indices = [0u32; K];
     base_2b(md, a32, k32, &mut indices);
 
@@ -208,63 +203,62 @@ pub(crate) fn fors_pk_from_sig<
         // 6: node[0] ← F(PK.seed, ADRS, sk)
         let mut node_0 = (hashers.f)(pk_seed, &adrs, &sk);
 
-        // 7:
-        // 8: auth ← SIGFORS.getAUTH(i)    ▷ SIGFORS [(i · (a + 1) + 1) · n : (i + 1) · (a + 1) · n]
+        // 7: auth ← SIGFORS.getAUTH(i)    ▷ SIGFORS [(i · (a + 1) + 1) · n : (i + 1) · (a + 1) · n]
         let auth = sig_fors.auth[i as usize].clone();
 
-        // 9: for j from 0 to a − 1 do    ▷ Compute root from leaf and AUTH
+        // 8: for j from 0 to a − 1 do    ▷ Compute root from leaf and AUTH
         for j in 0..a32 {
             //
-            // 10: ADRS.setTreeHeight(j + 1)
+            // 9: ADRS.setTreeHeight(j + 1)
             adrs.set_tree_height(j + 1);
 
-            // 11: if indices[i]/2^j is even then
+            // 10: if indices[i]/2^j is even then
             let node_1 = if ((indices[i as usize] >> j) % 2) == 0 {
                 //
-                // 12: ADRS.setTreeIndex(ADRS.getTreeIndex()/2)
+                // 11: ADRS.setTreeIndex(ADRS.getTreeIndex()/2)
                 let tmp = adrs.get_tree_index() / 2;
                 adrs.set_tree_index(tmp);
 
-                // 13: node[1] ← H(PK.seed, ADRS, node[0] ∥ auth[j])
+                // 12: node[1] ← H(PK.seed, ADRS, node[0] ∥ auth[j])
                 (hashers.h)(pk_seed, &adrs, &node_0, &auth.tree[j as usize])
 
-                // 14: else
+                // 13: else
             } else {
                 //
-                // 15: ADRS.setTreeIndex((ADRS.getTreeIndex() − 1)/2)
+                // 14: ADRS.setTreeIndex((ADRS.getTreeIndex() − 1)/2)
                 let tmp = (adrs.get_tree_index() - 1) / 2;
                 adrs.set_tree_index(tmp);
 
-                // 16: node[1] ← H(PK.seed, ADRS, auth[j] ∥ node[0])
+                // 15: node[1] ← H(PK.seed, ADRS, auth[j] ∥ node[0])
                 (hashers.h)(pk_seed, &adrs, &auth.tree[j as usize], &node_0)
 
-                // 17: end if
+                // 16: end if
             };
 
-            // 18: node[0] ← node[1]
+            // 17: node[0] ← node[1]
             node_0 = node_1;
 
-            // 19: end for
+            // 18: end for
         }
 
-        // 20: root[i] ← node[0]
+        // 19: root[i] ← node[0]
         root[i as usize] = node_0;
 
-        // 21: end for
+        // 20: end for
     }
 
-    // 22: forspkADRS ← ADRS    ▷ Compute the FORS public key from the Merkle tree roots
+    // 21: forspkADRS ← ADRS    ▷ copy address to create a FORS public-key address
     let mut fors_pk_adrs = adrs.clone();
 
-    // 23: forspkADRS.setTypeAndClear(FORS_ROOTS)
+    // 22: forspkADRS.setTypeAndClear(FORS_ROOTS)
     fors_pk_adrs.set_type_and_clear(FORS_ROOTS);
 
-    // 24: forspkADRS.setKeyPairAddress(ADRS.getKeyPairAddress())
+    // 23: forspkADRS.setKeyPairAddress(ADRS.getKeyPairAddress())
     fors_pk_adrs.set_key_pair_address(adrs.get_key_pair_address());
 
-    // 25: pk ← Tk(PK.seed, forspkADRS, root)
+    // 24: pk ← Tk(PK.seed, forspkADRS, root)   ▷ compute the FORS public key
     let pk = (hashers.t_len)(pk_seed, &fors_pk_adrs, &root);
 
-    // 26: return pk;
+    // 25: return pk;
     ForsPk { key: pk }
 }

--- a/src/hashers.rs
+++ b/src/hashers.rs
@@ -40,7 +40,7 @@ pub(crate) mod shake {
         r: &[u8], pk_seed: &[u8], pk_root: &[u8], domain_sep: u8, ctx: &[u8], oid: &[u8], m: &[u8],
     ) -> [u8; M] {
         let mut digest = [0u8; M];
-        shake256(&[r, pk_seed, pk_root, &[domain_sep], &[ctx.len() as u8], oid, m], &mut digest);
+        shake256(&[r, pk_seed, pk_root, &[domain_sep], &[ctx.len() as u8], ctx, oid, m], &mut digest);
         digest
     }
 
@@ -57,7 +57,7 @@ pub(crate) mod shake {
         ctx: &[u8], oid: &[u8], m: &[u8]
     ) -> [u8; N] {
         let mut digest = [0u8; N];
-        shake256(&[sk_prf, opt_rand, &[domain_sep], &[ctx.len() as u8], oid, m], &mut digest);
+        shake256(&[sk_prf, opt_rand, &[domain_sep], &[ctx.len() as u8], ctx, oid, m], &mut digest);
         digest
     }
 

--- a/src/hashers.rs
+++ b/src/hashers.rs
@@ -4,9 +4,9 @@ use crate::types::Adrs;
 // Holds hasher function references; constructed by each security parameter set wrapper
 #[allow(clippy::type_complexity)]
 pub(crate) struct Hashers<const K: usize, const LEN: usize, const M: usize, const N: usize> {
-    pub(crate) h_msg: fn(&[u8], &[u8], &[u8], &[u8]) -> [u8; M],
+    pub(crate) h_msg: fn(&[u8], &[u8], &[u8], u8, &[u8], &[u8], &[u8]) -> [u8; M],
     pub(crate) prf: fn(&[u8], &[u8], &Adrs) -> [u8; N],
-    pub(crate) prf_msg: fn(&[u8], &[u8], &[u8]) -> [u8; N],
+    pub(crate) prf_msg: fn(&[u8], &[u8], u8, &[u8], &[u8], &[u8]) -> [u8; N],
     pub(crate) f: fn(&[u8], &Adrs, &[u8]) -> [u8; N],
     pub(crate) h: fn(&[u8], &Adrs, &[u8], &[u8]) -> [u8; N],
     pub(crate) t_l: fn(&[u8], &Adrs, &[[u8; N]; LEN]) -> [u8; N],
@@ -37,10 +37,10 @@ pub(crate) mod shake {
 
 
     pub(crate) fn h_msg<const M: usize>(
-        r: &[u8], pk_seed: &[u8], pk_root: &[u8], m: &[u8],
+        r: &[u8], pk_seed: &[u8], pk_root: &[u8], domain_sep: u8, ctx: &[u8], oid: &[u8], m: &[u8],
     ) -> [u8; M] {
         let mut digest = [0u8; M];
-        shake256(&[r, pk_seed, pk_root, m], &mut digest);
+        shake256(&[r, pk_seed, pk_root, &[domain_sep], &[ctx.len() as u8], oid, m], &mut digest);
         digest
     }
 
@@ -53,9 +53,11 @@ pub(crate) mod shake {
     }
 
 
-    pub(crate) fn prf_msg<const N: usize>(sk_prf: &[u8], opt_rand: &[u8], m: &[u8]) -> [u8; N] {
+    pub(crate) fn prf_msg<const N: usize>(sk_prf: &[u8], opt_rand: &[u8], domain_sep: u8,
+        ctx: &[u8], oid: &[u8], m: &[u8]
+    ) -> [u8; N] {
         let mut digest = [0u8; N];
-        shake256(&[sk_prf, opt_rand, m], &mut digest);
+        shake256(&[sk_prf, opt_rand, &[domain_sep], &[ctx.len() as u8], oid, m], &mut digest);
         digest
     }
 
@@ -106,10 +108,10 @@ pub(crate) mod sha2_cat_1 {
 
 
     pub(crate) fn h_msg<const M: usize>(
-        r: &[u8], pk_seed: &[u8], pk_root: &[u8], m: &[u8],
+        r: &[u8], pk_seed: &[u8], pk_root: &[u8], domain_sep: u8, ctx: &[u8], oid: &[u8], m: &[u8],
     ) -> [u8; M] {
         let mut digest1 = [0u8; 32];
-        sha2_256(&[r, pk_seed, pk_root, m], &mut digest1);
+        sha2_256(&[r, pk_seed, pk_root, &[domain_sep], &[ctx.len() as u8], ctx, oid, m], &mut digest1);
         let mut result = [0u8; M];
         let mut start = 0;
         let mut counter = 0u32;
@@ -134,7 +136,7 @@ pub(crate) mod sha2_cat_1 {
     }
 
 
-    fn hmac_sha_256(key: &[u8], a0: &[u8], b1: &[u8]) -> [u8; 32] {
+    fn hmac_sha_256(key: &[u8], a0: &[u8], b1: &[&[u8]]) -> [u8; 32] {
         let mut padding = [0x36; 64];
         for (p, &k) in padding.iter_mut().zip(key.iter()) {
             *p ^= k;
@@ -142,7 +144,7 @@ pub(crate) mod sha2_cat_1 {
         let mut inner_hasher = Sha256::new();
         inner_hasher.update(&padding[..]);
         inner_hasher.update(a0);
-        inner_hasher.update(b1);
+        b1.iter().for_each(|item| inner_hasher.update(item));
         for p in &mut padding {
             *p ^= 0x6a;
         }
@@ -153,9 +155,11 @@ pub(crate) mod sha2_cat_1 {
     }
 
 
-    pub(crate) fn prf_msg<const N: usize>(sk_prf: &[u8], opt_rand: &[u8], m: &[u8]) -> [u8; N] {
+    pub(crate) fn prf_msg<const N: usize>(sk_prf: &[u8], opt_rand: &[u8], domain_sep: u8,
+        ctx: &[u8], oid: &[u8], m: &[u8]
+    ) -> [u8; N] {
         let mut digest = [0u8; N];
-        let full_digest = hmac_sha_256(sk_prf, opt_rand, m);
+        let full_digest = hmac_sha_256(sk_prf, opt_rand, &[&[domain_sep], &[ctx.len() as u8], ctx, oid, m]);
         digest.copy_from_slice(&full_digest[0..N]);
         digest
     }
@@ -223,10 +227,10 @@ pub(crate) mod sha2_cat_3_5 {
 
 
     pub(crate) fn h_msg<const M: usize>(
-        r: &[u8], pk_seed: &[u8], pk_root: &[u8], m: &[u8],
+        r: &[u8], pk_seed: &[u8], pk_root: &[u8], domain_sep: u8, ctx: &[u8], oid: &[u8], m: &[u8],
     ) -> [u8; M] {
         let mut digest1 = [0u8; 64];
-        sha2_512(&[r, pk_seed, pk_root, m], &mut digest1);
+        sha2_512(&[r, pk_seed, pk_root, &[domain_sep], &[ctx.len() as u8], ctx, oid, m], &mut digest1);
         let mut result = [0u8; M];
         let mut start = 0;
         let mut counter = 0u32;
@@ -251,7 +255,7 @@ pub(crate) mod sha2_cat_3_5 {
     }
 
 
-    fn hmac_sha_512(key: &[u8], a0: &[u8], b1: &[u8]) -> [u8; 64] {
+    fn hmac_sha_512(key: &[u8], a0: &[u8], b1: &[&[u8]]) -> [u8; 64] {
         let mut padding = [0x36; 128];
         for (p, &k) in padding.iter_mut().zip(key.iter()) {
             *p ^= k;
@@ -259,7 +263,7 @@ pub(crate) mod sha2_cat_3_5 {
         let mut inner_hasher = Sha512::new();
         inner_hasher.update(&padding[..]);
         inner_hasher.update(a0);
-        inner_hasher.update(b1);
+        b1.iter().for_each(|item| inner_hasher.update(item));
         for p in &mut padding {
             *p ^= 0x6a;
         }
@@ -270,9 +274,11 @@ pub(crate) mod sha2_cat_3_5 {
     }
 
 
-    pub(crate) fn prf_msg<const N: usize>(sk_prf: &[u8], opt_rand: &[u8], m: &[u8]) -> [u8; N] {
+    pub(crate) fn prf_msg<const N: usize>(sk_prf: &[u8], opt_rand: &[u8], domain_sep: u8,
+        ctx: &[u8], oid: &[u8], m: &[u8]
+    ) -> [u8; N] {
         let mut digest = [0u8; N];
-        let full_digest = hmac_sha_512(sk_prf, opt_rand, m);
+        let full_digest = hmac_sha_512(sk_prf, opt_rand, &[&[domain_sep], &[ctx.len() as u8], ctx, oid, m]);
         digest.copy_from_slice(&full_digest[0..N]);
         digest
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,8 +1,8 @@
 use crate::types::{Adrs, Auth, ForsSig, HtSig, SlhDsaSig, WotsSig, XmssSig};
 
 
-/// Algorithm 1: `toInt(X, n)` on page 14.
-/// Convert a byte string to an integer.
+/// Algorithm 2: `toInt(X, n)` on page 15.
+/// Converts a byte string to an integer.
 ///
 /// Input: n-byte string `X`, string length `n`. <br>
 /// Output: Integer value of `X`.
@@ -13,23 +13,22 @@ pub(crate) fn to_int(x: &[u8], n: u32) -> u64 {
     // 1: total ← 0
     let mut total = 0;
 
-    // 2:
-    // 3: for i from 0 to n − 1 do
+    // 2: for i from 0 to n − 1 do
     for item in x.iter().take(n as usize) {
         //
-        // 4: total ← 256 · total + X[i]
+        // 3: total ← 256 · total + X[i]
         total = (total << 8) + u64::from(*item);
 
-        // 5: end for
+        // 4: end for
     }
 
-    // 6: return total
+    // 5: return total
     total
 }
 
 
-/// Algorithm 2: `toByte(x, n)` on page 15.
-/// Convert an integer to a byte string.
+/// Algorithm 3: `toByte(x, n)` on page 15.
+/// Converts an integer to a byte string.
 ///
 /// Input: Integer `x`, string length `n`. <br>
 /// Output: Byte string of length `n` containing binary representation of `x` in big-endian byte-order.
@@ -41,26 +40,25 @@ pub(crate) fn to_byte(x: u32, n: u32) -> [u8; ((crate::LEN2 * crate::LGW + 7) / 
     // 1: total ← x
     let mut total = x;
 
-    // 2:
-    // 3: for i from 0 to n − 1 do
+    // 2: for i from 0 to n − 1 do
     for i in 0..n {
         //
-        // 4: S[n − 1 − i] ← total mod 256    ▷ Least significant 8 bits of total
+        // 3: S[n − 1 − i] ← total mod 256    ▷ Least significant 8 bits of total
         s[(n - 1 - i) as usize] = total.to_le_bytes()[0];
 
-        // 5: total ← total ≫ 8
+        // 4: total ← total ≫ 8
         total >>= 8;
 
-        // 6: end for
+        // 5: end for
     }
 
-    // 7: return S
+    // 6: return S
     s
 }
 
 
-/// Algorithm 3: `base_2^b(X, b, out_len)` on page 15.
-/// Compute the base 2^b representation of X.
+/// Algorithm 4: `base_2^b(X, b, out_len)` on page 16.
+/// Computes the base 2^b representation of X.
 ///
 /// Input: Byte string `X` of length at least `ceil(out_len·b/8)`, integer `b`, output length `out_len`. <br>
 /// Output: Array of `out_len` integers in the range `[0, . . . , 2^b − 1]`.
@@ -78,35 +76,34 @@ pub(crate) fn base_2b(x: &[u8], b: u32, out_len: u32, baseb: &mut [u32]) {
     // 3: total ← 0
     let mut total = 0;
 
-    // 4:
-    // 5: for out from 0 to out_len − 1 do
+    // 4: for out from 0 to out_len − 1 do
     for item in baseb.iter_mut() {
         //
-        // 6: while bits < b do
+        // 5: while bits < b do
         while bits < b {
             //
-            // 7: total ← (total ≪ 8) + X[in]
+            // 6: total ← (total ≪ 8) + X[in]
             total = (total << 8) + u32::from(x[inn]);
 
-            // 8: in ← in + 1
+            // 7: in ← in + 1
             inn += 1;
 
-            // 9: bits ← bits + 8
+            // 8: bits ← bits + 8
             bits += 8;
 
-            // 10: end while
+            // 9: end while
         }
 
-        // 11: bits ← bits − b
+        // 10: bits ← bits − b
         bits -= b;
 
-        // 12: baseb[out] ← (total ≫ bits) mod 2^b
+        // 11: baseb[out] ← (total ≫ bits) mod 2^b
         *item = (total >> bits) & (u32::MAX >> (32 - b));
 
-        // 13: end for
+        // 12: end for
     }
 
-    // 14: return baseb  (mutable parameter)
+    // 13: return baseb  (mutable parameter)
 }
 
 

--- a/src/hypertree.rs
+++ b/src/hypertree.rs
@@ -3,8 +3,8 @@ use crate::types::{Adrs, HtSig, WotsSig, XmssSig};
 use crate::xmss;
 
 
-/// Algorithm 11: `ht_sign(M, SK.seed, PK.seed, idx_tree, idx_leaf)` on page 27.
-/// Generate a hypertree signature.
+/// Algorithm 12: `ht_sign(M, SK.seed, PK.seed, idx_tree, idx_leaf)` on page 27.
+/// Generates a hypertree signature.
 ///
 /// Input: Message `M`, private seed `SK.seed`, public seed `PK.seed`, tree index `idx_tree`, leaf
 /// index `idx_leaf`. <br>
@@ -28,15 +28,14 @@ pub(crate) fn ht_sign<
     // 1: ADRS ← toByte(0, 32)
     let mut adrs = Adrs::default();
 
-    // 2:
-    // 3: ADRS.setTreeAddress(idxtree)
+    // 2: ADRS.setTreeAddress(idxtree)
     adrs.set_tree_address(idx_tree);
 
-    // 4: SIG_tmp ← xmss_sign(M, SK.seed, idxleaf, PK.seed, ADRS)
+    // 3: SIG_tmp ← xmss_sign(M, SK.seed, idxleaf, PK.seed, ADRS)
     let mut sig_tmp =
         xmss::xmss_sign::<H, HP, K, LEN, M, N>(hashers, m, sk_seed, idx_leaf, pk_seed, &adrs)?;
 
-    // 5: SIG_HT ← SIG_tmp
+    // 4: SIG_HT ← SIG_tmp
     let mut sig_ht = HtSig {
         xmss_sigs: core::array::from_fn(|_| XmssSig {
             sig_wots: WotsSig { data: [[0u8; N]; LEN] },
@@ -45,55 +44,55 @@ pub(crate) fn ht_sign<
     };
     sig_ht.xmss_sigs[0] = sig_tmp.clone();
 
-    // 6: root ← xmss_PKFromSig(idx_leaf, SIG_tmp, M, PK.seed, ADRS)
+    // 5: root ← xmss_PKFromSig(idx_leaf, SIG_tmp, M, PK.seed, ADRS)
     let mut root =
         xmss::xmss_pk_from_sig::<HP, K, LEN, M, N>(hashers, idx_leaf, &sig_tmp, m, pk_seed, &adrs);
 
-    // 7: for j from 1 to d − 1 do
+    // 6: for j from 1 to d − 1 do
     for j in 1..d32 {
         //
-        // 8: idx_leaf ← idx_tree mod 2^{h′}    ▷ h′ least significant bits of idx_tree
+        // 7: idx_leaf ← idx_tree mod 2^{h′}    ▷ h′ least significant bits of idx_tree
         let idx_leaf =
-            u32::try_from(idx_tree & ((1 << hp32) - 1)).map_err(|_| "Alg11: oversized idx leaf")?;
+            u32::try_from(idx_tree & ((1 << hp32) - 1)).map_err(|_| "Alg12: oversized idx leaf")?;
 
-        // 9: idx_tree ← idx_tree ≫ h′    ▷ Remove least significant h′ bits from idx_tree
+        // 8: idx_tree ← idx_tree ≫ h′    ▷ Remove least significant h′ bits from idx_tree
         idx_tree >>= hp32;
 
-        // 10: ADRS.setLayerAddress(j)
+        // 9: ADRS.setLayerAddress(j)
         adrs.set_layer_address(j);
 
-        // 11: ADRS.setTreeAddress(idx_tree)
+        // 10: ADRS.setTreeAddress(idx_tree)
         adrs.set_tree_address(idx_tree);
 
-        // 12: SIG_tmp ← xmss_sign(root, SK.seed, idx_leaf, PK.seed, ADRS)
+        // 11: SIG_tmp ← xmss_sign(root, SK.seed, idx_leaf, PK.seed, ADRS)
         sig_tmp = xmss::xmss_sign::<H, HP, K, LEN, M, N>(
             hashers, &root, sk_seed, idx_leaf, pk_seed, &adrs,
         )?;
 
-        // 13: SIG_HT ← SIG_HT ∥ SIG_tmp
+        // 12: SIG_HT ← SIG_HT ∥ SIG_tmp
         sig_ht.xmss_sigs[j as usize] = sig_tmp.clone();
 
-        // 14: if j < d − 1 then
+        // 13: if j < d − 1 then
         if j < (d32 - 1) {
             //
-            // 15: root ← xmss_PKFromSig(idx_leaf, SIG_tmp, root, PK.seed, ADRS)
+            // 14: root ← xmss_PKFromSig(idx_leaf, SIG_tmp, root, PK.seed, ADRS)
             root = xmss::xmss_pk_from_sig::<HP, K, LEN, M, N>(
                 hashers, idx_leaf, &sig_tmp, &root, pk_seed, &adrs,
             );
 
-            // 16: end if
+            // 15: end if
         }
 
-        // 17: end for
+        // 16: end for
     }
 
-    // 18: return SIGHT
+    // 17: return SIGHT
     Ok(sig_ht)
 }
 
 
-/// Algorithm 12: `ht_verify(M, SIG_HT, PK.seed, idx_tree, idx_leaf, PK.root)` on page 28.
-/// Verify a hypertree signature.
+/// Algorithm 13: `ht_verify(M, SIG_HT, PK.seed, idx_tree, idx_leaf, PK.root)` on page 28.
+/// Verifies a hypertree signature.
 ///
 /// Input: Message `M`, signature `SIG_HT`, public seed `PK.seed`, tree index `idx_tree`, leaf index `idx_leaf`,
 /// HT public key `PK.root`. <br>
@@ -115,20 +114,19 @@ pub(crate) fn ht_verify<
     // 1: ADRS ← toByte(0, 32)
     let mut adrs = Adrs::default();
 
-    // 2:
-    // 3: ADRS.setTreeAddress(idx_tree)
+    // 2: ADRS.setTreeAddress(idx_tree)
     adrs.set_tree_address(idx_tree);
 
-    // 4: SIG_tmp ← SIG_HT.getXMSSSignature(0)    ▷ SIG_HT [0 : (h′ + len) · n]
+    // 3: SIG_tmp ← SIG_HT.getXMSSSignature(0)    ▷ SIG_HT [0 : (h′ + len) · n]
     let sig_tmp = sig_ht.xmss_sigs[0].clone();
 
-    // 5: node ← xmss_PKFromSig(idx_leaf, SIG_tmp, M, PK.seed, ADRS)
+    // 4: node ← xmss_PKFromSig(idx_leaf, SIG_tmp, M, PK.seed, ADRS)
     let mut node = xmss::xmss_pk_from_sig(hashers, idx_leaf, &sig_tmp, m, pk_seed, &adrs);
 
-    // 6: for j from 1 to d − 1 do
+    // 5: for j from 1 to d − 1 do
     for j in 1..d32 {
         //
-        // 7: idx_leaf ← idx_tree mod 2^{h′}    ▷ h′ least significant bits of idx_tree
+        // 6: idx_leaf ← idx_tree mod 2^{h′}    ▷ h′ least significant bits of idx_tree
         let idx_leaf = u32::try_from(idx_tree & ((1 << hp32) - 1));
 
         if idx_leaf.is_err() {
@@ -136,28 +134,28 @@ pub(crate) fn ht_verify<
         };
         let idx_leaf = idx_leaf.unwrap();
 
-        // 8: idx_tree ← idx_tree ≫ h′    ▷ Remove least significant h′ bits from idx_tree
+        // 7: idx_tree ← idx_tree ≫ h′    ▷ Remove least significant h′ bits from idx_tree
         idx_tree >>= hp32;
 
-        // 9: ADRS.setLayerAddress(j)
+        // 8: ADRS.setLayerAddress(j)
         adrs.set_layer_address(j);
 
-        // 10: ADRS.setTreeAddress(idx_tree)
+        // 9: ADRS.setTreeAddress(idx_tree)
         adrs.set_tree_address(idx_tree);
 
-        // 11: SIG_tmp ← SIG_HT.getXMSSSignature(j)     ▷ SIGHT [ j · (h′ + len) · n : ( j + 1)(h′ + len) · n]
+        // 10: SIG_tmp ← SIG_HT.getXMSSSignature(j)     ▷ SIGHT [ j · (h′ + len) · n : ( j + 1)(h′ + len) · n]
         let sig_tmp = sig_ht.xmss_sigs[j as usize].clone();
 
-        // 12: node ← xmss_PKFromSig(idx_leaf, SIG_tmp, node, PK.seed, ADRS)
+        // 11: node ← xmss_PKFromSig(idx_leaf, SIG_tmp, node, PK.seed, ADRS)
         node = xmss::xmss_pk_from_sig(hashers, idx_leaf, &sig_tmp, &node, pk_seed, &adrs);
 
-        // 13: end for
+        // 12: end for
     }
 
-    // 14: if node = PK.root then
-    // 15:   return true
-    // 16: else
-    // 17:   return false
-    // 18: end if
+    // 13: if node = PK.root then
+    // 14:   return true
+    // 15: else
+    // 16:   return false
+    // 17: end if
     node == *pk_root // TODO: CT equal (is this in signing path??)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,11 +171,11 @@ macro_rules! functionality {
         impl Signer for PrivateKey {
             type Signature = [u8; SIG_LEN];
 
-            fn try_sign_with_rng_ct(
-                &self, rng: &mut impl CryptoRngCore, m: &[u8], randomize: bool,
+            fn try_sign_with_rng_and_ctx_ct(
+                &self, rng: &mut impl CryptoRngCore, m: &[u8], ctx: &[u8], randomize: bool,
             ) -> Result<[u8; SIG_LEN], &'static str> {
                 let sig = crate::slh::slh_sign_with_rng::<A, D, H, HP, K, LEN, M, N>(
-                    rng, &HASHERS, &m, &self.0, randomize,
+                    rng, &HASHERS, &m, &ctx, &self.0, randomize,
                 );
                 sig.map(|s| s.deserialize())
             }
@@ -185,12 +185,12 @@ macro_rules! functionality {
         impl Verifier for PublicKey {
             type Signature = [u8; SIG_LEN];
 
-            fn try_verify_vt(
-                &self, m: &[u8], sig_bytes: &[u8; SIG_LEN],
+            fn try_verify_with_ctx_vt(
+                &self, m: &[u8], sig_bytes: &[u8; SIG_LEN], ctx: &[u8]
             ) -> Result<bool, &'static str> {
                 let sig = SlhDsaSig::<A, D, HP, K, LEN, N>::serialize(sig_bytes);
                 let res = crate::slh::slh_verify::<A, D, H, HP, K, LEN, M, N>(
-                    &HASHERS, &m, &sig, &self.0,
+                    &HASHERS, &m, &sig, &ctx, &self.0,
                 );
                 Ok(res)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,11 +279,11 @@ macro_rules! functionality {
                     let result = pk2.try_verify_with_ctx_vt(&message, &[0u8; SIG_LEN], &context).unwrap();
                     assert_eq!(result, false, "Signature should not have verified (Signature changed)");
                     message[3] = i + 1;
-                    let result = pk2.try_verify_vt(&message, &sig).unwrap();
+                    let result = pk2.try_verify_with_ctx_vt(&message, &sig, &context).unwrap();
                     assert_eq!(result, false, "Signature should not have verified (message changed)");
                     message[3] = i;
                     context[1] = 255 - i - 1; 
-                    let result = pk2.try_verify_vt(&message, &sig).unwrap();
+                    let result = pk2.try_verify_with_ctx_vt(&message, &sig, &context).unwrap();
                     assert_eq!(result, false, "Signature should not have verified (context changed)");
                 }
             }

--- a/src/slh.rs
+++ b/src/slh.rs
@@ -111,7 +111,6 @@ pub(crate) fn slh_sign_with_rng<
         .map_err(|_| "Alg22: rng failed")?;
 
     // 8: M' ← toByte(0, 1) ∥ toByte(|ctx|, 1) ∥ ctx ∥ M
-    // TODO: Find a way to make m' without allocating
 
     // 9: SIG ← slh_sign_internal(M', SK, addrnd)  ▷ omit addrnd for the deterministic variant
     // 10: return SIG
@@ -135,7 +134,7 @@ pub(crate) fn slh_sign_with_rng<
     };
 
     // 3: R ← PRF_msg(SK.prf, opt_rand, M)    ▷ Generate randomizer
-    let r = (hashers.prf_msg)(&sk.sk_prf, &opt_rand, m);
+    let r = (hashers.prf_msg)(&sk.sk_prf, &opt_rand, 0, ctx, &[], m);
 
     // 4: SIG ← R
     let mut sig = SlhDsaSig {
@@ -153,7 +152,7 @@ pub(crate) fn slh_sign_with_rng<
     };
 
     // 5: digest ← H_msg(R, PK.seed, PK.root, M)    ▷ Compute message digest
-    let digest = (hashers.h_msg)(&r, &sk.pk_seed, &sk.pk_root, m);
+    let digest = (hashers.h_msg)(&r, &sk.pk_seed, &sk.pk_root, 0, ctx, &[], m);
 
     // 6: md ← digest[0 : ceil(k·a/8)]    ▷ first ceil(k·a/8) bytes
     let index1 = (K * A + 7) / 8;
@@ -265,7 +264,7 @@ pub(crate) fn slh_verify<
     let sig_ht = &sig.ht_sig;
 
     // 8: digest ← Hmsg(R, PK.seed, PK.root, M)    ▷ Compute message digest
-    let digest = (hashers.h_msg)(r, &pk.pk_seed, &pk.pk_root, m);
+    let digest = (hashers.h_msg)(r, &pk.pk_seed, &pk.pk_root, 0, ctx, &[], m);
 
     // 9: md ← digest[0 : ceil(k·a/8)]    ▷ first ceil(k·a/8) bytes
     let index1 = (K * A + 7) / 8;

--- a/src/slh.rs
+++ b/src/slh.rs
@@ -76,10 +76,15 @@ pub(crate) fn slh_sign_with_rng<
     const M: usize,
     const N: usize,
 >(
-    rng: &mut impl CryptoRngCore, hashers: &Hashers<K, LEN, M, N>, m: &[u8], sk: &SlhPrivateKey<N>,
+    rng: &mut impl CryptoRngCore, hashers: &Hashers<K, LEN, M, N>, m: &[u8], ctx: &[u8], sk: &SlhPrivateKey<N>,
     randomize: bool,
 ) -> Result<SlhDsaSig<A, D, HP, K, LEN, N>, &'static str> {
     let (d32, h32) = (u32::try_from(D).unwrap(), u32::try_from(H).unwrap());
+
+    if ctx.len() > 255 {
+        return Err("Alg17: Context too large");
+    }
+
     //
     // 1: ADRS ← toByte(0, 32)
     let mut adrs = Adrs::default();
@@ -194,9 +199,11 @@ pub(crate) fn slh_verify<
     const N: usize,
 >(
     hashers: &Hashers<K, LEN, M, N>, m: &[u8], sig: &SlhDsaSig<A, D, HP, K, LEN, N>,
-    pk: &SlhPublicKey<N>,
+    ctx: &[u8], pk: &SlhPublicKey<N>,
 ) -> bool {
     let (d32, h32) = (u32::try_from(D).unwrap(), u32::try_from(H).unwrap());
+
+    assert_ne!(ctx.len() > 255, true, "Alg19: Context too large");
 
     // 1: if |SIG| != (1 + k(1 + a) + h + d · len) · n then
     // 2:   return false

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 
-/// Fig 16 on page 34
+/// Fig 17 on page 34
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct SlhDsaSig<
     const A: usize,
@@ -17,6 +17,7 @@ pub(crate) struct SlhDsaSig<
 }
 
 
+/// Fig 16 on page 33
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct SlhPublicKey<const N: usize> {
     pub(crate) pk_seed: [u8; N],
@@ -24,6 +25,7 @@ pub struct SlhPublicKey<const N: usize> {
 }
 
 
+/// Fig 15 on page 33
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub struct SlhPrivateKey<const N: usize> {
     pub(crate) sk_seed: [u8; N],
@@ -33,7 +35,7 @@ pub struct SlhPrivateKey<const N: usize> {
 }
 
 
-/// Fig 13 on page 29
+/// Fig 14 on page 29
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct ForsSig<const A: usize, const K: usize, const N: usize> {
     pub(crate) private_key_value: [[u8; N]; K],
@@ -47,19 +49,20 @@ pub(crate) struct ForsPk<const N: usize> {
 }
 
 
-/// Fig 10
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct Auth<const A: usize, const N: usize> {
     pub(crate) tree: [[u8; N]; A],
 }
 
 
+/// Fig 13 on page 26
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct HtSig<const D: usize, const HP: usize, const LEN: usize, const N: usize> {
     pub(crate) xmss_sigs: [XmssSig<HP, LEN, N>; D],
 }
 
 
+/// Fig 10 on page 19
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub struct WotsSig<const LEN: usize, const N: usize> {
     pub(crate) data: [[u8; N]; LEN],
@@ -70,6 +73,7 @@ pub struct WotsSig<const LEN: usize, const N: usize> {
 pub struct WotsPk<const N: usize>(pub(crate) [u8; N]);
 
 
+// Fig 11 on page 22
 #[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub struct XmssSig<const HP: usize, const LEN: usize, const N: usize> {
     pub(crate) sig_wots: WotsSig<LEN, N>,

--- a/src/wots.rs
+++ b/src/wots.rs
@@ -4,7 +4,7 @@ use crate::helpers::{base_2b, to_byte};
 use crate::types::{Adrs, WotsPk, WotsSig, WOTS_PK, WOTS_PRF};
 
 
-/// Algorithm 4: `chain(X, i, s, PK.seed, ADRS)` on page 17.
+/// Algorithm 5: `chain(X, i, s, PK.seed, ADRS)` on page 18.
 /// Chaining function used in WOTS+. The chain function takes as input an n-byte string `X` and integers `s` and `i`
 /// and returns the result of iterating the hash function `F` on the input `s` times, starting from an index of `i`.
 /// The chain function also requires as input PK.seed, which is part of the SLH-DSA public key, and an address `ADRS`.
@@ -20,39 +20,33 @@ pub(crate) fn chain<const K: usize, const LEN: usize, const M: usize, const N: u
     debug_assert!(i + s < u32::MAX);
     let mut adrs = adrs.clone();
 
-    // 1: if (i + s) ≥ w then
+    // Note this bounds check was only specified in the draft specification
     if (i + s) >= crate::W {
-        //
-        // 2: return NULL
         return None;
-
-        // 3: end if
     }
 
-    // 4:
-    // 5: tmp ← X
+    // 1: tmp ← X
     let mut tmp = cap_x;
 
-    // 6:
-    // 7: for j from i to i + s − 1 do
+    // 2: for j from i to i + s − 1 do
     for j in i..(i + s) {
         //
-        // 8: ADRS.setHashAddress(j)
+        // 3: ADRS.setHashAddress(j)
         adrs.set_hash_address(j);
 
-        // 9: tmp ← F(PK.seed, ADRS, tmp)
+        // 4: tmp ← F(PK.seed, ADRS, tmp)
         tmp = (hashers.f)(pk_seed, &adrs, &tmp);
 
-        // 10: end for
+        // 5: end for
     }
 
-    // 11: return tmp
+    // 6: return tmp
     Some(tmp)
 }
 
 
-/// Algorithm 5: `wots_PKgen(SK.seed, PK.seed, ADRS)` on page 18.
-/// Generate a WOTS+ public key. The `wots_PKgen` function generates WOTS+ public keys. It takes as input `SK.seed`
+/// Algorithm 6: `wots_PKgen(SK.seed, PK.seed, ADRS)` on page 18.
+/// Generates a WOTS+ public key. The `wots_PKgen` function generates WOTS+ public keys. It takes as input `SK.seed`
 /// and `PK.seed` from the SLH-DSA private key and an address. The type in the address `ADRS` must be set to
 /// `WOTS_HASH`, and the layer address, tree address, and key pair address must encode the address of the `WOTS+`
 /// public key to be generated.
@@ -112,8 +106,8 @@ pub(crate) fn wots_pkgen<const K: usize, const LEN: usize, const M: usize, const
 }
 
 
-/// Algorithm 6: `wots_sign(M, SK.seed, PK.seed, ADRS)` on page 19.
-/// Generate a WOTS+ signature on an n-byte message.
+/// Algorithm 7: `wots_sign(M, SK.seed, PK.seed, ADRS)` on page 20.
+/// Generates a WOTS+ signature on an n-byte message.
 ///
 /// Input: Message `M`, secret seed `SK.seed`, public seed `PK.seed`, address `ADRS`. <br>
 /// Output: WOTS+ signature sig.
@@ -128,26 +122,23 @@ pub(crate) fn wots_sign<const K: usize, const LEN: usize, const M: usize, const 
     // 1: csum ← 0
     let mut csum = 0_u32;
 
-    // 2:
-    // 3: msg ← base_2b(M, lgw, len1)    ▷ Convert message to base w
+    // 2: msg ← base_2b(M, lgw, len1)    ▷ Convert message to base w
     let mut msg = [0u32; LEN]; // note: 3 entries left over, used step 10
     helpers::base_2b(m, crate::LGW, 2 * n32, &mut msg[0..(2 * N)]);
 
-    // 4:
-    // 5: for i from 0 to len1 − 1 do    ▷ Compute checksum
+    // 3: for i from 0 to len1 − 1 do    ▷ Compute checksum
     for item in msg.iter().take(2 * N) {
         //
-        // 6: csum ← csum + w − 1 − msg[i]
+        // 4: csum ← csum + w − 1 − msg[i]
         csum += crate::W - 1 - *item;
 
-        // 7: end for
+        // 5: end for
     }
 
-    // 8:
-    // 9: csum ← csum ≪ ((8 − ((len2·lgw) mod 8)) mod 8)    ▷ For lgw = 4 left shift by 4
+    // 6: csum ← csum ≪ ((8 − ((len2·lgw) mod 8)) mod 8)    ▷ For lgw = 4 left shift by 4
     csum <<= (8 - ((crate::LEN2 * crate::LGW) & 0x07)) & 0x07;
 
-    // 10: msg ← msg ∥ base_2^b(toByte(csum, ceil(len2·lgw/8)), lgw, len2)    ▷ Convert csum to base w
+    // 7: msg ← msg ∥ base_2b(toByte(csum, ceil(len2·lgw/8)), lgw, len2)    ▷ Convert to base w
     helpers::base_2b(
         &helpers::to_byte(csum, (crate::LEN2 * crate::LGW + 7) / 8),
         crate::LGW,
@@ -155,41 +146,40 @@ pub(crate) fn wots_sign<const K: usize, const LEN: usize, const M: usize, const 
         &mut msg[(2 * N)..],
     );
 
-    // 11:
-    // 12: skADRS ← ADRS
+    // 8: skADRS ← ADRS
     let mut sk_addrs = adrs.clone();
 
-    // 13: skADRS.setTypeAndClear(WOTS_PRF)
+    // 9: skADRS.setTypeAndClear(WOTS_PRF)
     sk_addrs.set_type_and_clear(WOTS_PRF);
 
-    // 14: skADRS.setKeyPairAddress(ADRS.getKeyPairAddress())
+    // 10: skADRS.setKeyPairAddress(ADRS.getKeyPairAddress())
     sk_addrs.set_key_pair_address(adrs.get_key_pair_address());
 
-    // 15: for i from 0 to len − 1 do
+    // 11: for i from 0 to len − 1 do
     for (item, i) in msg.iter().zip(0u32..) {
         //
-        // 16: skADRS.setChainAddress(i)
+        // 12: skADRS.setChainAddress(i)
         sk_addrs.set_chain_address(i);
 
-        // 17: sk ← PRF(PK.seed, SK.seed, skADRS)    ▷ Compute secret value for chain i
+        // 13: sk ← PRF(PK.seed, SK.seed, skADRS)    ▷ Compute chain i secret value
         let sk = (hashers.prf)(pk_seed, sk_seed, &sk_addrs);
 
-        // 18: ADRS.setChainAddress(i)
+        // 14: ADRS.setChainAddress(i)
         adrs.set_chain_address(i);
 
-        // 19: sig[i] ← chain(sk, 0, msg[i], PK.seed, ADRS)    ▷ Compute signature value for chain i
+        // 15: sig[i] ← chain(sk, 0, msg[i], PK.seed, ADRS)    ▷ Compute chain i signature value
         sig.data[i as usize] = chain(hashers, sk, 0, *item, pk_seed, &adrs).unwrap();
 
-        // 20: end for
+        // 16: end for
     }
 
-    // 21: return sig
+    // 17: return sig
     sig
 }
 
 
-/// Algorithm 7: `wots_PKFromSig(sig, M, PK.seed, ADRS)` on page 20.
-/// Compute a WOTS+ public key from a message and its signature.
+/// Algorithm 8: `wots_PKFromSig(sig, M, PK.seed, ADRS)` on page 21.
+/// Computes a WOTS+ public key from a message and its signature.
 ///
 /// Input: WOTS+ signature `sig`, message `M`, public seed `PK.seed`, address `ADRS`. <br>
 /// Output: WOTS+ public key `pksig` derived from `sig`.
@@ -203,26 +193,23 @@ pub(crate) fn wots_pk_from_sig<const K: usize, const LEN: usize, const M: usize,
     // 1: csum ← 0
     let mut csum = 0_u32;
 
-    // 2:
-    // 3: msg ← base_2b (M, lgw , len1 )    ▷ Convert message to base w
+    // 2: msg ← base_2b (M, lgw , len1 )    ▷ Convert message to base w
     let mut msg = [0u32; LEN];
     base_2b(m, crate::LGW, 2 * n32, &mut msg[0..(2 * N)]);
 
-    // 4:
-    // 5: for i from 0 to len1 − 1 do    ▷ Compute checksum
+    // 3: for i from 0 to len1 − 1 do    ▷ Compute checksum
     for item in msg.iter().take(2 * N) {
         //
-        // 6:   csum ← csum + w − 1 − msg[i]
+        // 4:   csum ← csum + w − 1 − msg[i]
         csum += crate::W - 1 - item;
 
-        // 7: end for
+        // 5: end for
     }
 
-    // 8:
-    // 9: csum ← csum ≪ ((8 − ((len2·lgw) mod 8)) mod 8)    ▷ For lgw = 4 left shift by 4
+    // 6: csum ← csum ≪ ((8 − ((len2·lgw) mod 8)) mod 8)    ▷ For lgw = 4 left shift by 4
     csum <<= (8 - ((crate::LEN2 * crate::LGW) & 0x07)) & 0x07;
 
-    // 10: msg ← msg ∥ base_2^b(toByte(csum, ceil(len2·lgw/8)), lgw, len2)    ▷ Convert csum to base w
+    // 7: msg ← msg ∥ base_2b(toByte(csum, ceil(len2·lgw/8)), lgw, len2)    ▷ Convert to base w
     base_2b(
         &to_byte(csum, (crate::LEN2 * crate::LGW + 7) / 8),
         crate::LGW,
@@ -230,14 +217,14 @@ pub(crate) fn wots_pk_from_sig<const K: usize, const LEN: usize, const M: usize,
         &mut msg[(2 * N)..],
     );
 
-    // 11: for i from 0 to len − 1 do
-    #[allow(clippy::cast_possible_truncation)] // steps 12 and 13
+    // 8: for i from 0 to len − 1 do
+    #[allow(clippy::cast_possible_truncation)] // steps 9 and 10
     for i in 0..LEN {
         //
-        // 12: ADRS.setChainAddress(i)
+        // 9: ADRS.setChainAddress(i)
         adrs.set_chain_address(i as u32);
 
-        // 13: tmp[i] ← chain(sig[i], msg[i], w − 1 − msg[i], PK.seed, ADRS)
+        // 10: tmp[i] ← chain(sig[i], msg[i], w − 1 − msg[i], PK.seed, ADRS)
         tmp[i] = chain::<K, LEN, M, N>(
             hashers,
             sig.data[i],
@@ -246,23 +233,23 @@ pub(crate) fn wots_pk_from_sig<const K: usize, const LEN: usize, const M: usize,
             pk_seed,
             &adrs,
         )
-        .expect("chain broke2!");
+        .expect("chain broke!");
 
-        // 14: end for
+        // 11: end for
     }
 
-    // 15: wotspkADRS ← ADRS
+    // 12: wotspkADRS ← ADRS   ▷ copy address to create WOTS+ public key address
     let mut wotspk_adrs = adrs.clone();
 
-    // 16: wotspkADRS.setTypeAndClear(WOTS_PK)
+    // 13: wotspkADRS.setTypeAndClear(WOTS_PK)
     wotspk_adrs.set_type_and_clear(WOTS_PK);
 
-    // 17: wotspkADRS.setKeyPairAddress(ADRS.getKeyPairAddress())
+    // 14: wotspkADRS.setKeyPairAddress(ADRS.getKeyPairAddress())
     wotspk_adrs.set_key_pair_address(adrs.get_key_pair_address());
 
-    // 18: pksig ← Tlen (PK.seed, wotspkADRS, tmp)
+    // 15: pksig ← Tlen (PK.seed, wotspkADRS, tmp)
     let pk = (hashers.t_l)(pk_seed, &wotspk_adrs, &tmp);
 
-    // 19: return pksig
+    // 16: return pksig
     WotsPk(pk)
 }

--- a/src/xmss.rs
+++ b/src/xmss.rs
@@ -3,8 +3,8 @@ use crate::types::{Adrs, WotsSig, XmssSig, TREE, WOTS_HASH};
 use crate::wots;
 
 
-/// Algorithm 8: `xmss_node(SK.seed, i, z, PK.seed, ADRS)` on page 22.
-/// Compute the root of a Merkle subtree of WOTS+ public keys.
+/// Algorithm 9: `xmss_node(SK.seed, i, z, PK.seed, ADRS)` on page 23.
+/// Computes the root of a Merkle subtree of WOTS+ public keys.
 ///
 /// Input: Secret seed `SK.seed`, target node index `i`, target node height `z`, public seed `PK.seed`,
 /// `address ADRS`. <br>
@@ -23,60 +23,56 @@ pub(crate) fn xmss_node<
     let hp32 = u32::try_from(HP).unwrap();
     let mut adrs = adrs.clone();
 
-    // 1: if z > h′ or i ≥ 2^{h −z} then
+    // Note this bounds check was only specified in the draft specification
     if (z > hp32) | (u64::from(i) >= (1 << (hp32 - z))) {
-        //
-        // 2: return NULL
-        return Err("Alg8: fail");
-
-        // 3: end if
+        return Err("Alg9: fail");
     }
 
-    // 4: if z = 0 then
+    // 1: if z = 0 then
     let node = if z == 0 {
         //
-        // 5: ADRS.setTypeAndClear(WOTS_HASH)
+        // 2: ADRS.setTypeAndClear(WOTS_HASH)
         adrs.set_type_and_clear(WOTS_HASH);
 
-        // 6: ADRS.setKeyPairAddress(i)
+        // 3: ADRS.setKeyPairAddress(i)
         adrs.set_key_pair_address(i);
 
-        // 7: node ← wots_PKgen(SK.seed, PK.seed, ADRS)
+        // 4: node ← wots_PKgen(SK.seed, PK.seed, ADRS)
         wots::wots_pkgen::<K, LEN, M, N>(hashers, sk_seed, pk_seed, &adrs)?.0
 
-        // 8: else
+        // 5: else
     } else {
         //
-        // 9: lnode ← xmss_node(SK.seed, 2 * i, z − 1, PK.seed, ADRS)
+        // 6: lnode ← xmss_node(SK.seed, 2 * i, z − 1, PK.seed, ADRS)
         let lnode =
             xmss_node::<H, HP, K, LEN, M, N>(hashers, sk_seed, 2 * i, z - 1, pk_seed, &adrs)?;
 
-        // 10: rnode ← xmss_node(SK.seed, 2 * i + 1, z − 1, PK.seed, ADRS)
+        // 7: rnode ← xmss_node(SK.seed, 2 * i + 1, z − 1, PK.seed, ADRS)
         let rnode =
             xmss_node::<H, HP, K, LEN, M, N>(hashers, sk_seed, 2 * i + 1, z - 1, pk_seed, &adrs)?;
 
-        // 11: ADRS.setTypeAndClear(TREE)
+        // 8: ADRS.setTypeAndClear(TREE)
         adrs.set_type_and_clear(TREE);
 
-        // 12: ADRS.setTreeHeight(z)
+        // 9: ADRS.setTreeHeight(z)
         adrs.set_tree_height(z);
 
-        // 13: ADRS.setTreeIndex(i)
+        // 10: ADRS.setTreeIndex(i)
         adrs.set_tree_index(i);
 
-        // 14: node ← H(PK.seed, ADRS, lnode ∥ rnode)
+        // 11: node ← H(PK.seed, ADRS, lnode ∥ rnode)
         (hashers.h)(pk_seed, &adrs, &lnode, &rnode)
 
-        // 15: end if
+        // 12: end if
     };
 
-    // 16: return node
+    // 13: return node
     Ok(node)
 }
 
 
-/// Algorithm 9: `xmss_sign(M, SK.seed, idx, PK.seed, ADRS)` on page 23.
-/// Generate an XMSS signature.
+/// Algorithm 10: `xmss_sign(M, SK.seed, idx, PK.seed, ADRS)` on page 24.
+/// Generates an XMSS signature.
 ///
 /// Input: n-byte message `M`, secret seed `SK.seed`, index `idx`, public seed `PK.seed`, address `ADRS`. <br>
 /// Output: XMSS signature SIGXMSS = (sig ∥ AUTH).
@@ -112,26 +108,25 @@ pub(crate) fn xmss_sign<
         // 4: end for
     }
 
-    // 5:
-    // 6: ADRS.setTypeAndClear(WOTS_HASH)
+    // 5: ADRS.setTypeAndClear(WOTS_HASH)
     adrs.set_type_and_clear(WOTS_HASH);
 
-    // 7: ADRS.setKeyPairAddress(idx)
+    // 6: ADRS.setKeyPairAddress(idx)
     adrs.set_key_pair_address(idx);
 
-    // 8: sig ← wots_sign(M, SK.seed, PK.seed, ADRS)
+    // 7: sig ← wots_sign(M, SK.seed, PK.seed, ADRS)
     sig_xmss.sig_wots = wots::wots_sign::<K, LEN, M, N>(hashers, m, sk_seed, pk_seed, &adrs);
 
-    // 9: SIG_XMSS ← sig ∥ AUTH
+    // 8: SIG_XMSS ← sig ∥ AUTH
     // struct built above
 
-    // 10: return SIG_XMSS
+    // 9: return SIG_XMSS
     Ok(sig_xmss)
 }
 
 
-/// Algorithm 10: `xmss_PKFromSig(idx, SIG_XMSS, M, PK.seed, ADRS)`
-/// Compute an XMSS public key from an XMSS signature.
+/// Algorithm 11: `xmss_PKFromSig(idx, SIG_XMSS, M, PK.seed, ADRS)`
+/// Computes an XMSS public key from an XMSS signature.
 ///
 /// Input: Index `idx`, XMSS signature `SIG_XMSS = (sig ∥ AUTH)`, n-byte message `M`, public seed `PK.seed`,
 /// address `ADRS`. <br>
@@ -164,48 +159,47 @@ pub(crate) fn xmss_pk_from_sig<
     // 5: node[0] ← wots_PKFromSig(sig, M, PK.seed, ADRS)
     let mut node_0 = wots::wots_pk_from_sig::<K, LEN, M, N>(hashers, sig, m, pk_seed, &adrs).0;
 
-    // 6:
-    // 7: ADRS.setTypeAndClear(TREE)    ▷ Compute root from WOTS+ pk and AUTH
+    // 6: ADRS.setTypeAndClear(TREE)    ▷ Compute root from WOTS+ pk and AUTH
     adrs.set_type_and_clear(TREE);
 
-    // 8: ADRS.setTreeIndex(idx)
+    // 7: ADRS.setTreeIndex(idx)
     adrs.set_tree_index(idx);
 
-    // 9: for k from 0 to h′ − 1 do
+    // 8: for k from 0 to h′ − 1 do
     for k in 0..hp32 {
         //
-        // 10: ADRS.setTreeHeight(k + 1)
+        // 9: ADRS.setTreeHeight(k + 1)
         adrs.set_tree_height(k + 1);
 
-        // 11: if idx/2^k is even then
+        // 10: if idx/2^k is even then
         let node_1 = if ((idx >> k) & 1) == 0 {
             //
-            // 12: ADRS.setTreeIndex(ADRS.getTreeIndex()/2)
+            // 11: ADRS.setTreeIndex(ADRS.getTreeIndex()/2)
             let tmp = adrs.get_tree_index() / 2;
             adrs.set_tree_index(tmp);
 
-            // 13: node[1] ← H(PK.seed, ADRS, node[0] ∥ AUTH[k])
+            // 12: node[1] ← H(PK.seed, ADRS, node[0] ∥ AUTH[k])
             (hashers.h)(pk_seed, &adrs, &node_0, &auth[k as usize])
 
-            // 14: else
+            // 13: else
         } else {
             //
-            // 15: ADRS.setTreeIndex((ADRS.getTreeIndex() − 1)/2)
+            // 14: ADRS.setTreeIndex((ADRS.getTreeIndex() − 1)/2)
             let tmp = (adrs.get_tree_index() - 1) / 2;
             adrs.set_tree_index(tmp);
 
-            // 16: node[1] ← H(PK.seed, ADRS, AUTH[k] ∥ node[0])
+            // 15: node[1] ← H(PK.seed, ADRS, AUTH[k] ∥ node[0])
             (hashers.h)(pk_seed, &adrs, &auth[k as usize], &node_0)
 
-            // 17: end if
+            // 16: end if
         };
 
-        // 18: node[0] ← node[1]
+        // 17: node[0] ← node[1]
         node_0 = node_1;
 
-        // 19: end for
+        // 18: end for
     }
 
-    // 20: return node[0]
+    // 19: return node[0]
     node_0
 }


### PR DESCRIPTION
FIP205 now requires the message to be pre-pended with some additional information before being signed or verified. This PR is intended to implement those changes.

The functions should now sign/verify the message as altered:
M' = 0x0 || ctx.len() as u8 || ctx || M
Where 
 - 0x0 is the domain separator indicating this is a pure signing function as opposed to a pre-hash signing function.
 - ctx.len() as u8 is the length of the context limited to 8 bits
 - ctx is the context
 - M is the message to be signed

Updating comments to match released FIPS 205 is in scope for this PR

Adding pre-hash versions of the sign and verify functions are out of scope for this PR